### PR TITLE
Safely read environment variables into Front-End

### DIFF
--- a/client/source/index.jsx
+++ b/client/source/index.jsx
@@ -7,6 +7,7 @@ import AppHolder from './AppHolder';
 
 
 // MAIN
+console.info('HOST:', `http://${process.env.SITE_URL}:${process.env.PORT}`);
 const root = createRoot(document.getElementById('root'));
 root.render(
   <AppHolder />

--- a/client/source/utilities/axiosRequests.js
+++ b/client/source/utilities/axiosRequests.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
-
-const authServerURL = 'http://localhost:3000';
+const authServerURL = `http://${process.env.SITE_URL}:${process.env.PORT}`;
 
 /**
  * Fire an Axios Get Request.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@testing-library/user-event": "^14.4.3",
         "babel-loader": "^9.1.2",
         "babel-plugin-styled-components": "^2.0.7",
+        "dotenv-webpack": "^8.0.1",
         "eslint": "^8.32.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-plugin-import": "^2.27.5",
@@ -5040,6 +5041,39 @@
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-defaults/node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-webpack": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
+      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
+      "dev": true,
+      "dependencies": {
+        "dotenv-defaults": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": "^4 || ^5"
       }
     },
     "node_modules/ee-first": {
@@ -16175,6 +16209,32 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+    },
+    "dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dev": true,
+      "requires": {
+        "dotenv": "^8.2.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+          "dev": true
+        }
+      }
+    },
+    "dotenv-webpack": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
+      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
+      "dev": true,
+      "requires": {
+        "dotenv-defaults": "^2.0.2"
+      }
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@testing-library/user-event": "^14.4.3",
     "babel-loader": "^9.1.2",
     "babel-plugin-styled-components": "^2.0.7",
+    "dotenv-webpack": "^8.0.1",
     "eslint": "^8.32.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.27.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const Dotenv = require('dotenv-webpack'); // eslint-disable-line
 
 module.exports = {
   mode: 'development', // as opposed to `production` which obfuscates namespaces
@@ -7,6 +8,9 @@ module.exports = {
     path: path.join(__dirname, '/client/dist'),
     filename: 'bundle.js'
   },
+  plugins: [
+    new Dotenv()
+  ],
   devtool: 'source-map', // creates a file to relate compiled code to source code for debugging use
   module: {
     rules: [


### PR DESCRIPTION
this uses dotenv-webpack to load values from `.env`, but _only the ones you use_ so your github token is still safe.